### PR TITLE
fix: more leniency with URL format in mountpoint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,9 +49,9 @@ jobs:
   semantic-release:
     executor: node14
     steps:
-    - add_ssh_keys:
-        fingerprints:
-          - "89:43:ce:9f:4a:d4:ad:32:47:ef:46:db:03:cd:e4:31"
+      - add_ssh_keys:
+          fingerprints:
+            - "89:43:ce:9f:4a:d4:ad:32:47:ef:46:db:03:cd:e4:31"
       - setup
       - run:
           name: revert changes to package-lock.json

--- a/src/extension/utils.js
+++ b/src/extension/utils.js
@@ -131,10 +131,10 @@ export function getConfigMatches(configs, tabUrl, proxyUrl) {
                 return false;
               }
               // editor url, check for site name in path
-              const pathSegments = mpPath.split('/');
-              pathSegments.shift();
-              const site = encodeURIComponent(pathSegments
-                .find((s) => s !== 's' && s !== 'sites' && !s.startsWith(':')));
+              if (!mpPath.includes('/sites/')) {
+                return false;
+              }
+              const site = mpPath.split('/sites/')[1].split('/').shift();
               return pathname.includes(`/sites/${site}/`);
             } else if (checkHost === 'drive.google.com') {
               // gdrive browser


### PR DESCRIPTION
Fix #7 

Support any of the following URL formats:
```
https://adobe.sharepoint.com/:f:/r/sites/MySite/Shared%20Documents/website
https://adobe.sharepoint.com/sites/MySite/Shared%20Documents/website
```