### PR TITLE
fix: config picker text too low

### DIFF
--- a/src/extension/configpicker.js
+++ b/src/extension/configpicker.js
@@ -79,7 +79,7 @@ class ConfigPicker extends HTMLElement {
     let configContainer = pluginContainer;
 
     const label = document.createElement('span');
-    label.style.margin = '16px 8px 0 0';
+    label.style.margin = '6px 8px 0 0';
     label.textContent = `${i18n('config_project_pick')}:`;
     root.prepend(label);
 


### PR DESCRIPTION
With the latest sidekick CSS, the text on the config picker toolbar is hanging 10px too low.

<img width="162" alt="image" src="https://user-images.githubusercontent.com/1609742/161973102-86cdcbc8-0077-4f30-8c03-8888289d87a6.png">
