### PR TITLE
feat: show save hint for onedrive

### DIFF
--- a/src/extension/app.css
+++ b/src/extension/app.css
@@ -899,6 +899,22 @@
   content: "Please wait...";
 }
 
+.hlx-sk-overlay .modal.modal-preview-onedrive::before {
+  content: "Pro tip: Press Control + S before previewing to see the latest changes immediately...";
+}
+
+.hlx-sk-overlay .modal.modal-preview-onedrive-mac::before {
+  content: "Pro tip: Press Command + S before previewing to see the latest changes immediately...";
+}
+
+.hlx-sk-overlay .modal.modal-reload-onedrive::before {
+  content: "Pro tip: Press Control + S in the editor before reloading a page...";
+}
+
+.hlx-sk-overlay .modal.modal-reload-onedrive-mac::before {
+  content: "Pro tip: Press Command + S in the editor before reloading a page...";
+}
+
 .hlx-sk-overlay .modal.modal-share-success::before {
   content: "Sharing URL copied to clipboard.";
 }

--- a/src/extension/app.css
+++ b/src/extension/app.css
@@ -900,19 +900,19 @@
 }
 
 .hlx-sk-overlay .modal.modal-preview-onedrive::before {
-  content: "Pro tip: Press Control + S before previewing to see the latest changes immediately...";
+  content: "Pro tip: Press Ctrl + S before previewing to see the latest changes immediately...";
 }
 
 .hlx-sk-overlay .modal.modal-preview-onedrive-mac::before {
-  content: "Pro tip: Press Command + S before previewing to see the latest changes immediately...";
+  content: "Pro tip: Press ⌘ + S before previewing to see the latest changes immediately...";
 }
 
 .hlx-sk-overlay .modal.modal-reload-onedrive::before {
-  content: "Pro tip: Press Control + S in the editor before reloading a page...";
+  content: "Pro tip: Press Ctrl + S in the editor before reloading a page...";
 }
 
 .hlx-sk-overlay .modal.modal-reload-onedrive-mac::before {
-  content: "Pro tip: Press Command + S in the editor before reloading a page...";
+  content: "Pro tip: Press ⌘ + S in the editor before reloading a page...";
 }
 
 .hlx-sk-overlay .modal.modal-share-success::before {

--- a/src/extension/de.css
+++ b/src/extension/de.css
@@ -151,11 +151,11 @@
 }
 
 .hlx-sk-overlay .modal.modal-reload-onedrive::before {
-  content: "Expertenhinweis: Drücke vor dem Aktualisieren einer Seite im Editor Control + S...";
+  content: "Expertenhinweis: Drücke vor dem Aktualisieren einer Seite im Editor Ctrl + S...";
 }
 
 .hlx-sk-overlay .modal.modal-reload-onedrive-mac::before {
-  content: "Expertenhinweis: Drücke vor dem Aktualisieren einer Seite im Editor Command + S...";
+  content: "Expertenhinweis: Drücke vor dem Aktualisieren einer Seite im Editor ⌘ + S...";
 }
 
 .hlx-sk-overlay .modal.modal-share-success::before {

--- a/src/extension/de.css
+++ b/src/extension/de.css
@@ -142,6 +142,22 @@
   content: "Bitte warten...";
 }
 
+.hlx-sk-overlay .modal.modal-preview-onedrive::before {
+  content: "Expertenhinweis: Drücke vor der Vorschau Control + S, um immer die neusten Änderungen zu sehen...";
+}
+
+.hlx-sk-overlay .modal.modal-preview-onedrive-mac::before {
+  content: "Expertenhinweis: Drücke vor der Vorschau Command + S, um immer die neusten Änderungen zu sehen...";
+}
+
+.hlx-sk-overlay .modal.modal-reload-onedrive::before {
+  content: "Expertenhinweis: Drücke vor dem Aktualisieren einer Seite im Editor Control + S...";
+}
+
+.hlx-sk-overlay .modal.modal-reload-onedrive-mac::before {
+  content: "Expertenhinweis: Drücke vor dem Aktualisieren einer Seite im Editor Command + S...";
+}
+
 .hlx-sk-overlay .modal.modal-share-success::before {
   content: "Teilen-URL in die Benutzerablage kopiert.";
 }

--- a/src/extension/fr.css
+++ b/src/extension/fr.css
@@ -142,6 +142,22 @@
   content: "Veuillez patienter...";
 }
 
+.hlx-sk-overlay .modal.modal-preview-onedrive::before {
+  content: "Pro tip: Press Control + S before previewing to see the latest changes immediately...";
+}
+
+.hlx-sk-overlay .modal.modal-preview-onedrive-mac::before {
+  content: "Pro tip: Press Command + S before previewing to see the latest changes immediately...";
+}
+
+.hlx-sk-overlay .modal.modal-reload-onedrive::before {
+  content: "Pro tip: Press Control + S in the editor before reloading a page...";
+}
+
+.hlx-sk-overlay .modal.modal-reload-onedrive-mac::before {
+  content: "Pro tip: Press Command + S in the editor before reloading a page...";
+}
+
 .hlx-sk-overlay .modal.modal-share-success::before {
   content: "L'URL de partage a été copiée dans le presse-papier.";
 }

--- a/src/extension/fr.css
+++ b/src/extension/fr.css
@@ -143,19 +143,19 @@
 }
 
 .hlx-sk-overlay .modal.modal-preview-onedrive::before {
-  content: "Astuce: Pour voir les derniers changements immédiatement, appuyez sur Control + S avant de générer l'aperçu...";
+  content: "Astuce: Pour voir les derniers changements immédiatement, appuyez sur Ctrl + S avant de générer l'aperçu...";
 }
 
 .hlx-sk-overlay .modal.modal-preview-onedrive-mac::before {
-  content: "Astuce: Pour voir les derniers changements immédiatement, appuyez sur &#8984; + S avant de générer l'aperçu...";
+  content: "Astuce: Pour voir les derniers changements immédiatement, appuyez sur ⌘; + S avant de générer l'aperçu...";
 }
 
 .hlx-sk-overlay .modal.modal-reload-onedrive::before {
-  content: "Astuce: Appuyez sur Control + S dans l'éditeur avant de recharger la page...";
+  content: "Astuce: Appuyez sur Ctrl + S dans l'éditeur avant de recharger la page...";
 }
 
 .hlx-sk-overlay .modal.modal-reload-onedrive-mac::before {
-  content: "Astuce: Appuyez sur &#8984; + S dans l'éditeur avant de recharger la page...";
+  content: "Astuce: Appuyez sur ⌘ + S dans l'éditeur avant de recharger la page...";
 }
 
 .hlx-sk-overlay .modal.modal-share-success::before {

--- a/src/extension/fr.css
+++ b/src/extension/fr.css
@@ -143,19 +143,19 @@
 }
 
 .hlx-sk-overlay .modal.modal-preview-onedrive::before {
-  content: "Pro tip: Press Control + S before previewing to see the latest changes immediately...";
+  content: "Astuce: Pour voir les derniers changements immédiatement, appuyez sur Control + S avant de générer l'aperçu...";
 }
 
 .hlx-sk-overlay .modal.modal-preview-onedrive-mac::before {
-  content: "Pro tip: Press Command + S before previewing to see the latest changes immediately...";
+  content: "Astuce: Pour voir les derniers changements immédiatement, appuyez sur &#8984; + S avant de générer l'aperçu...";
 }
 
 .hlx-sk-overlay .modal.modal-reload-onedrive::before {
-  content: "Pro tip: Press Control + S in the editor before reloading a page...";
+  content: "Astuce: Appuyez sur Control + S dans l'éditeur avant de recharger la page...";
 }
 
 .hlx-sk-overlay .modal.modal-reload-onedrive-mac::before {
-  content: "Pro tip: Press Command + S in the editor before reloading a page...";
+  content: "Astuce: Appuyez sur &#8984; + S dans l'éditeur avant de recharger la page...";
 }
 
 .hlx-sk-overlay .modal.modal-share-success::before {

--- a/src/extension/module.js
+++ b/src/extension/module.js
@@ -955,7 +955,16 @@
             }
             sk.switchEnv('preview', newTab(evt));
           };
-          sk.showWait();
+          if (status.edit && status.edit.sourceLocation
+            && status.edit.sourceLocation.startsWith('onedrive:')) {
+            // show ctrl/cmd + s hint on onedrive docs
+            const mac = navigator.platform.toLowerCase().includes('mac') ? '-mac' : '';
+            sk.showModal({
+              css: `modal-preview-onedrive${mac}`,
+            });
+          } else {
+            sk.showWait();
+          }
           updatePreview();
         },
         isEnabled: (sidekick) => sidekick.isAuthorized('preview', 'write')
@@ -975,8 +984,17 @@
       condition: (s) => s.config.innerHost && (s.isInner() || s.isDev()),
       button: {
         action: async (evt) => {
-          const { location } = sk;
-          sk.showWait();
+          const { status, location } = sk;
+          if (status.edit && status.edit.sourceLocation
+            && status.edit.sourceLocation.startsWith('onedrive:')) {
+            // show ctrl/cmd + s hint on onedrive docs
+            const mac = navigator.platform.toLowerCase().includes('mac') ? '-mac' : '';
+            sk.showModal({
+              css: `modal-reload-onedrive${mac}`,
+            });
+          } else {
+            sk.showWait();
+          }
           try {
             const resp = await sk.update();
             if (!resp.ok && resp.status >= 400) {


### PR DESCRIPTION
Fix #119 

When a user clicks _preview_ in edit mode or _reload_ in preview mode, a hint to always pro-actively save the document in onedrive/sharepoint will be displayed.

![image](https://user-images.githubusercontent.com/1609742/187075505-c19e4f79-4710-4dec-b0d2-31a4f7dcf04a.png)
