### PR TITLE
feat: show extension hint to bookmarklet users

### DIFF
--- a/test/app.test.js
+++ b/test/app.test.js
@@ -668,4 +668,15 @@ describe('Test sidekick bookmarklet', () => {
     }).run();
     assert.ok(checkPageResult, 'Did not show login dialog on 401');
   });
+
+  it('Shows extension hint', async () => {
+    const { notification } = await new SidekickTest({
+      page,
+      allowNavigation: true,
+    }).run();
+    assert.ok(
+      notification.message && notification.message.startsWith('Did you know that the Sidekick is also available'),
+      'Did not show extension hint',
+    );
+  });
 });

--- a/test/login.test.js
+++ b/test/login.test.js
@@ -53,7 +53,6 @@ describe('Test sidekick login', () => {
     let loggedIn = false;
     const test = new SidekickTest({
       page,
-      loadModule: true,
       apiResponses: (req) => {
         if (req.headers.cookie === 'auth_token=foobar') {
           loggedIn = true;
@@ -70,6 +69,8 @@ describe('Test sidekick login', () => {
         };
       },
       waitPopup: 2000,
+      // suppress extension hint
+      pre: (p) => p.evaluate(() => window.localStorage.setItem('hlxSidekickExtensionHint', Date.now() + 31536000000)),
       post: async (p) => {
         const btn = await p.waitForFunction(() => window.hlx.sidekick.shadowRoot.querySelector('.hlx-sk .user div.user-login button'));
         await btn.click();
@@ -108,11 +109,12 @@ describe('Test sidekick login', () => {
   it('Opens login window and shows aborted modal', async () => {
     const test = new SidekickTest({
       page,
-      loadModule: true,
       apiResponses: [{
         status: 401,
       }],
       waitPopup: 2000,
+      // suppress extension hint
+      pre: (p) => p.evaluate(() => window.localStorage.setItem('hlxSidekickExtensionHint', Date.now() + 31536000000)),
       post: async (p) => {
         const btn = await p.waitForFunction(() => window.hlx.sidekick.shadowRoot.querySelector('.hlx-sk .user div.user-login button'));
         await btn.click();

--- a/test/login.test.js
+++ b/test/login.test.js
@@ -53,6 +53,7 @@ describe('Test sidekick login', () => {
     let loggedIn = false;
     const test = new SidekickTest({
       page,
+      loadModule: true,
       apiResponses: (req) => {
         if (req.headers.cookie === 'auth_token=foobar') {
           loggedIn = true;
@@ -107,6 +108,7 @@ describe('Test sidekick login', () => {
   it('Opens login window and shows aborted modal', async () => {
     const test = new SidekickTest({
       page,
+      loadModule: true,
       apiResponses: [{
         status: 401,
       }],


### PR DESCRIPTION
#159 

To test:
1. Turn off sidekick extension on `chrome://extensions`
2. Go to https://sidekick-issue-159--helix-website--adobe.hlx.live/tools/sidekick/
3. Enter a GH URL of a test project
4. Drag the white sidekick button to your toolbar
5. Navigate to a URL on your test project and click the bookmarklet