### PR TITLE
#167 Add ability to pass additional sk config info to url via passConfig param

### DIFF
--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -82,6 +82,10 @@
           "type": "url",
           "description": "The URL to open when the button is clicked"
         },
+        "passInfo": {
+          "type": "boolean",
+          "description": "Append ref, repo, owner, host, and project as query params on new URL button click"
+        },
         "passReferrer": {
           "type": "boolean",
           "description": "Append the referrer URL as a query param on new URL button click"

--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -82,7 +82,7 @@
           "type": "url",
           "description": "The URL to open when the button is clicked"
         },
-        "passInfo": {
+        "passConfig": {
           "type": "boolean",
           "description": "Append ref, repo, owner, host, and project as query params on new URL button click"
         },

--- a/src/extension/module.js
+++ b/src/extension/module.js
@@ -61,6 +61,8 @@
    * @prop {string} title The button text
    * @prop {Object} titleI18n={} A map of translated button texts
    * @prop {string} url The URL to open when the button is clicked
+   * @prop {boolean} passInfo Append additional sk info to the url as query parameters:
+   *                          ref, repo, owner, host, project
    * @prop {boolean} passReferrer Append the referrer URL as a query param on new URL button click
    * @prop {string} event The name of a custom event to fire when the button is clicked.
    *                      Note: Plugin events get a custom: prefix, e.g. "foo" becomes "custom:foo".
@@ -1195,6 +1197,7 @@
             title,
             titleI18n,
             url,
+            passInfo,
             passReferrer,
             isPalette,
             paletteRect,
@@ -1254,9 +1257,15 @@
               action: () => {
                 if (url) {
                   const target = url.startsWith('/') ? new URL(url, `https://${innerHost}/`) : new URL(url);
+                  if (passInfo) {
+                    target.searchParams.append('ref', sk.config.ref);
+                    target.searchParams.append('repo', sk.config.repo);
+                    target.searchParams.append('owner', sk.config.owner);
+                    target.searchParams.append('host', sk.config.host);
+                    target.searchParams.append('project', sk.config.project);
+                  }
                   if (passReferrer) {
-                    const { searchParams } = target;
-                    searchParams.append('referrer', location.href);
+                    target.searchParams.append('referrer', location.href);
                   }
                   if (isPalette) {
                     let palette = sk.shadowRoot.getElementById(`hlx-sk-palette-${id}`);

--- a/src/extension/module.js
+++ b/src/extension/module.js
@@ -61,7 +61,7 @@
    * @prop {string} title The button text
    * @prop {Object} titleI18n={} A map of translated button texts
    * @prop {string} url The URL to open when the button is clicked
-   * @prop {boolean} passInfo Append additional sk info to the url as query parameters:
+   * @prop {boolean} passConfig Append additional sk info to the url as query parameters:
    *                          ref, repo, owner, host, project
    * @prop {boolean} passReferrer Append the referrer URL as a query param on new URL button click
    * @prop {string} event The name of a custom event to fire when the button is clicked.
@@ -1197,7 +1197,7 @@
             title,
             titleI18n,
             url,
-            passInfo,
+            passConfig,
             passReferrer,
             isPalette,
             paletteRect,
@@ -1257,12 +1257,12 @@
               action: () => {
                 if (url) {
                   const target = url.startsWith('/') ? new URL(url, `https://${innerHost}/`) : new URL(url);
-                  if (passInfo) {
+                  if (passConfig) {
                     target.searchParams.append('ref', sk.config.ref);
                     target.searchParams.append('repo', sk.config.repo);
                     target.searchParams.append('owner', sk.config.owner);
-                    target.searchParams.append('host', sk.config.host);
-                    target.searchParams.append('project', sk.config.project);
+                    if (sk.config.host) target.searchParams.append('host', sk.config.host);
+                    if (sk.config.project) target.searchParams.append('project', sk.config.project);
                   }
                   if (passReferrer) {
                     target.searchParams.append('referrer', location.href);

--- a/test/module.test.js
+++ b/test/module.test.js
@@ -251,6 +251,38 @@ describe('Test sidekick module', () => {
     assert.ok(popupOpened === expectedPopupUrl, 'Did not pass referrer in plugin URL');
   }).timeout(IT_DEFAULT_TIMEOUT);
 
+  it('Plugin passes additional info in url', async () => {
+    const pluginUrl = 'https://www.hlx.live/';
+    const expectedInfoParam = '?ref=main&repo=blog&owner=adobe&host=undefined&project=';
+    const expectedPopupUrl = `${pluginUrl}${expectedInfoParam}`;
+    const mockUrl = `/${expectedInfoParam}`;
+
+    nock('https://www.hlx.live')
+      .get(mockUrl)
+      .reply(200, 'some content...');
+
+    const test = new SidekickTest({
+      page,
+      loadModule: true,
+      configJson: `{
+        "plugins": [{
+          "id": "bar",
+          "title": "Bar",
+          "url": "${pluginUrl}",
+          "passInfo": true
+        }]
+      }`,
+      plugin: 'bar',
+      pluginSleep: 2000,
+    });
+    const {
+      plugins,
+      popupOpened,
+    } = await test.run();
+    assert.ok(plugins.find((p) => p.id === 'bar'), 'Did not load plugins from project');
+    assert.ok(popupOpened === expectedPopupUrl, 'Did not pass additional info in plugin URL');
+  }).timeout(IT_DEFAULT_TIMEOUT);
+
   it('Plugin shows palette', async () => {
     const test = new SidekickTest({
       page,

--- a/test/module.test.js
+++ b/test/module.test.js
@@ -251,9 +251,9 @@ describe('Test sidekick module', () => {
     assert.ok(popupOpened === expectedPopupUrl, 'Did not pass referrer in plugin URL');
   }).timeout(IT_DEFAULT_TIMEOUT);
 
-  it('Plugin passes additional info in url', async () => {
+  it('Plugin passes config info into url using passConfig', async () => {
     const pluginUrl = 'https://www.hlx.live/';
-    const expectedInfoParam = '?ref=main&repo=blog&owner=adobe&host=undefined&project=';
+    const expectedInfoParam = '?ref=main&repo=blog&owner=adobe';
     const expectedPopupUrl = `${pluginUrl}${expectedInfoParam}`;
     const mockUrl = `/${expectedInfoParam}`;
 
@@ -269,7 +269,7 @@ describe('Test sidekick module', () => {
           "id": "bar",
           "title": "Bar",
           "url": "${pluginUrl}",
-          "passInfo": true
+          "passConfig": true
         }]
       }`,
       plugin: 'bar',


### PR DESCRIPTION
When `passConfig: true`, url gets:
`&ref=...&repo=...&owner=...&host=...&project=...`