### PR TITLE
fix: #170 - allow pushdown when editing google doc

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adobe/helix-sidekick-extension",
-  "version": "5.9.0",
+  "version": "6.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@adobe/helix-sidekick-extension",
-      "version": "5.9.0",
+      "version": "6.1.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@adobe/eslint-config-helix": "1.3.2",

--- a/src/extension/module.js
+++ b/src/extension/module.js
@@ -1601,10 +1601,9 @@
    * @param {number} skHeight The current height of the sidekick (optional)
    */
   function pushDownContent(sk, skHeight) {
-    const { config, location } = sk;
+    const { config } = sk;
     if (config.pushDown
-      && !sk.hasAttribute('pushdown')
-      && location.host !== 'docs.google.com') {
+      && !sk.hasAttribute('pushdown')) {
       window.setTimeout(() => {
         if (!skHeight) {
           skHeight = parseFloat(window.getComputedStyle(sk.root).height, 10);
@@ -1635,10 +1634,9 @@
    * @param {Sidekick} sk The sidekick
    */
   function revertPushDownContent(sk) {
-    const { config, location } = sk;
+    const { config } = sk;
     if (config.pushDown
-      && sk.hasAttribute('pushdown')
-      && location.host !== 'docs.google.com') {
+      && sk.hasAttribute('pushdown')) {
       sk.removeAttribute('pushdown');
       config.pushDownElements.forEach((elem) => {
         elem.style.marginTop = 'initial';


### PR DESCRIPTION
Fixed by simply removing the docs.google.com host checks. This worked for me when tested locally, but as I said in the linked issue, not totally clear why those checks were necessary to begin with. If more to it, let me know and happy to iterate as needed.

Please ensure your pull request adheres to the following guidelines:
- [x] make sure to link the related issues in this description
- [x] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues
#170

Thanks for contributing!
