### PR TITLE
feat: show the View Document Source context menu item if site is a Franklin site

### DIFF
--- a/src/extension/background.js
+++ b/src/extension/background.js
@@ -102,11 +102,36 @@ async function getProxyUrl({ id, url: tabUrl }) {
 }
 
 /**
+ * Tries to guess if the current tab is a Franklin site.
+ * @param {Object} The tab
+ * @returns {Promise<Boolean>} True if the provided tab is a Franklin site
+ */
+async function guessIfFranklinSite({ id }) {
+  return new Promise((resolve) => {
+    chrome.scripting.executeScript({
+      target: { tabId: id },
+      func: () => {
+        const isHelixSite = document.head.querySelectorAll('script[src*="scripts.js"]').length > 0
+          && document.head.querySelectorAll('link[href*="styles.css"]').length > 0
+          && document.body.querySelector('main > div.section') !== null;
+        chrome.runtime.sendMessage({ isHelixSite });
+      },
+    });
+    // listen for response message from tab
+    const listener = ({ isHelixSite }) => {
+      chrome.runtime.onMessage.removeListener(listener);
+      resolve(isHelixSite);
+    };
+    chrome.runtime.onMessage.addListener(listener);
+  });
+}
+
+/**
  * Enables or disables context menu items for a tab.
- * @param {string} tabUrl The URL of the tab
+ * @param {Object} tab The tab
  * @param {Object[]} configs The existing configurations
  */
-async function checkContextMenu(tabUrl, configs = []) {
+async function checkContextMenu({ url: tabUrl, id }, configs = []) {
   if (chrome.contextMenus) {
     // clear context menu
     chrome.contextMenus.removeAll(() => {
@@ -135,6 +160,12 @@ async function checkContextMenu(tabUrl, configs = []) {
               ],
             });
           }
+        }
+      }
+
+      // add the open view doc context menu item only if the current tab is a Frankin site (guess)
+      guessIfFranklinSite({ id }).then((isHelixSite) => {
+        if (isHelixSite) {
           chrome.contextMenus.create({
             id: 'openViewDocSource',
             title: i18n('open_view_doc_source'),
@@ -143,7 +174,7 @@ async function checkContextMenu(tabUrl, configs = []) {
             ],
           });
         }
-      }
+      });
     });
   }
 }
@@ -165,7 +196,7 @@ function checkTab(id) {
         checkUrl = await getProxyUrl(tab);
       }
       if (tab.active) {
-        checkContextMenu(tab.url, projects);
+        checkContextMenu(tab, projects);
       }
       if (new URL(checkUrl).pathname === SHARE_PREFIX) {
         log.debug('share url detected, inject install helper');
@@ -263,21 +294,29 @@ async function updateHelpContent() {
 }
 
 /**
- * Checks if the view source popp needs to be openeded, and opens it if necessary.
+ * Open the view document source popup
+ * @param {String} id The tab id
+ */
+function openViewDocSource(id) {
+  chrome.windows.create({
+    url: chrome.runtime.getURL(`/view-doc-source/index.html?tabId=${id}`),
+    type: 'popup',
+    width: 740,
+  });
+}
+
+/**
+ * Checks if the view document source popup needs to be openeded, and opens it if necessary.
  * @param {*} id The tab ID
  */
-function checkViewSource(id) {
+function checkViewDocSource(id) {
   chrome.tabs.get(id, (tab = {}) => {
     if (!tab.url) return;
     try {
       const u = new URL(tab.url);
       const vds = u.searchParams.get('view-doc-source');
       if (vds && vds === 'true') {
-        chrome.windows.create({
-          url: chrome.runtime.getURL(`/view-doc-source/index.html?tabId=${id}`),
-          type: 'popup',
-          width: 740,
-        });
+        openViewDocSource(id);
       }
     } catch (e) {
       log.warn('error checking view source', e);
@@ -332,7 +371,7 @@ function checkViewSource(id) {
         }
       }
     },
-    openViewDocSource: async ({ id }) => checkViewSource(id),
+    openViewDocSource: async ({ id }) => openViewDocSource(id),
   };
 
   if (chrome.contextMenus) {
@@ -353,7 +392,7 @@ function checkViewSource(id) {
     // wait until the tab is done loading
     if (info.status === 'complete') {
       checkTab(id);
-      checkViewSource(id);
+      checkViewDocSource(id, true);
     }
   });
 

--- a/src/extension/background.js
+++ b/src/extension/background.js
@@ -111,16 +111,16 @@ async function guessIfFranklinSite({ id }) {
     chrome.scripting.executeScript({
       target: { tabId: id },
       func: () => {
-        const isHelixSite = document.head.querySelectorAll('script[src*="scripts.js"]').length > 0
+        const isFranklinSite = document.head.querySelectorAll('script[src*="scripts.js"]').length > 0
           && document.head.querySelectorAll('link[href*="styles.css"]').length > 0
           && document.body.querySelector('main > div.section') !== null;
-        chrome.runtime.sendMessage({ isHelixSite });
+        chrome.runtime.sendMessage({ isFranklinSite });
       },
     });
     // listen for response message from tab
-    const listener = ({ isHelixSite }) => {
+    const listener = ({ isFranklinSite }) => {
       chrome.runtime.onMessage.removeListener(listener);
-      resolve(isHelixSite);
+      resolve(isFranklinSite);
     };
     chrome.runtime.onMessage.addListener(listener);
   });
@@ -164,8 +164,8 @@ async function checkContextMenu({ url: tabUrl, id }, configs = []) {
       }
 
       // add the open view doc context menu item only if the current tab is a Franklin site (guess)
-      guessIfFranklinSite({ id }).then((isHelixSite) => {
-        if (isHelixSite) {
+      guessIfFranklinSite({ id }).then((isFranklinSite) => {
+        if (isFranklinSite) {
           chrome.contextMenus.create({
             id: 'openViewDocSource',
             title: i18n('open_view_doc_source'),

--- a/src/extension/background.js
+++ b/src/extension/background.js
@@ -163,7 +163,7 @@ async function checkContextMenu({ url: tabUrl, id }, configs = []) {
         }
       }
 
-      // add the open view doc context menu item only if the current tab is a Frankin site (guess)
+      // add the open view doc context menu item only if the current tab is a Franklin site (guess)
       guessIfFranklinSite({ id }).then((isHelixSite) => {
         if (isHelixSite) {
           chrome.contextMenus.create({


### PR DESCRIPTION
The "View Document Source" context menu item if the site in the current is a Franklin site: even if you have no config for it, it should be possible to view the source, i.e. we must "guess" if the site is ours. Check if `scripts.js`, `styles.css` and `main > div.section` should do the trick.