### PR TITLE
Better error messages for Word Docs and Excel Sheets [NEED TRANSLATION HELP]

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "6.6.0",
   "description": "Franklin Sidekick Extension",
   "scripts": {
-    "lint": "./node_modules/.bin/eslint . --fix",
+    "lint": "./node_modules/.bin/eslint .",
     "test:mocha": "nyc mocha",
     "test:wtr": "wtr \"./test/unit/*.test.js\" \"./test/extension/*.test.js\" \"./test/view-doc-source/*.test.js\"",
     "test:wtr:watch": "npm run test:wtr -- --watch",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "6.6.0",
   "description": "Franklin Sidekick Extension",
   "scripts": {
-    "lint": "./node_modules/.bin/eslint .",
+    "lint": "./node_modules/.bin/eslint . --fix",
     "test:mocha": "nyc mocha",
     "test:wtr": "wtr \"./test/unit/*.test.js\" \"./test/extension/*.test.js\" \"./test/view-doc-source/*.test.js\"",
     "test:wtr:watch": "npm run test:wtr -- --watch",

--- a/src/extension/app.css
+++ b/src/extension/app.css
@@ -986,14 +986,13 @@
   content: "Previewing failed. Must be Google document or spreadsheet.";
 }
 
-.hlx-sk-overlay .modal.modal-preview-not-gdoc-ms-doc::before {
-  content: "Previewing failed. This is a Microsoft Doc. Please convert it to a Google Doc: 'File' > 'Save As Google Doc'";
+.hlx-sk-overlay .modal.modal-preview-not-gdoc-ms-word::before {
+  content: "This is a Microsoft Word document. Please convert it to Google Docs: File > Save as Google Docs";
 }
 
-.hlx-sk-overlay .modal.modal-preview-not-gdoc-ms-excel::before {
-  content: "Previewing failed. This is an Excel Sheets Document. Please convert it to Google Sheets: 'File' > 'Save As Google Sheets'";
+.hlx-sk-overlay .modal.modal-preview-not-gsheet-ms-excel::before {
+  content: "This is a Microsoft Excel document. Please convert it to Google Sheets: File > Save as Google Sheets'";
 }
-
 
 .hlx-sk-overlay .modal.modal-reload-failure::before {
   content: "Reloading failed. Please try again later.";

--- a/src/extension/app.css
+++ b/src/extension/app.css
@@ -982,9 +982,18 @@
   content: "Previewing failed. Please try again later.";
 }
 
-.hlx-sk-overlay .modal.modal-preview-not-gdoc::before {
+.hlx-sk-overlay .modal.modal-preview-not-gdoc-generic::before {
   content: "Previewing failed. Must be Google document or spreadsheet.";
 }
+
+.hlx-sk-overlay .modal.modal-preview-not-gdoc-ms-doc::before {
+  content: "Previewing failed. This is a Microsoft Doc. Please convert it to a Google Doc: 'File' > 'Save As Google Doc'";
+}
+
+.hlx-sk-overlay .modal.modal-preview-not-gdoc-ms-excel::before {
+  content: "Previewing failed. This is an Excel Sheets Document. Please convert it to Google Sheets: 'File' > 'Save As Google Sheets'";
+}
+
 
 .hlx-sk-overlay .modal.modal-reload-failure::before {
   content: "Reloading failed. Please try again later.";

--- a/src/extension/de.css
+++ b/src/extension/de.css
@@ -183,7 +183,7 @@
 }
 
 .hlx-sk-overlay .modal.modal-preview-not-gsheet-ms-excel::before {
-  content: "Dies ist ein Microsoft Word-Dokument. Bitte in Google-Tabelle umwandeln: Datei > Als Google-Tabelle speichern";
+  content: "Dies ist ein Microsoft Excel-Dokument. Bitte in Google-Tabelle umwandeln: Datei > Als Google-Tabelle speichern";
 }
 
 .hlx-sk-overlay .modal.modal-reload-failure::before {

--- a/src/extension/de.css
+++ b/src/extension/de.css
@@ -178,11 +178,11 @@
   content: "Vorschau-Generierung fehlgeschlagen. Muss ein Google-Dokument oder eine Tabelle sein.";
 }
 
-.hlx-sk-overlay .modal.modal-preview-not-gdoc-ms-doc::before {
+.hlx-sk-overlay .modal.modal-preview-not-gdoc-ms-word::before {
   content: "Previewing failed. This is a Microsoft Doc. Please convert it to a Google Doc: 'File' > 'Save As Google Doc'";
 }
 
-.hlx-sk-overlay .modal.modal-preview-not-gdoc-ms-excel::before {
+.hlx-sk-overlay .modal.modal-preview-not-gsheet-ms-excel::before {
   content: "Previewing failed. This is an Excel Sheets Document. Please convert it to Google Sheets: 'File' > 'Save As Google Sheets'";
 }
 

--- a/src/extension/de.css
+++ b/src/extension/de.css
@@ -174,8 +174,16 @@
   content: "Vorschau-Generierung fehlgeschlagen. Bitte versuche es später noch einmal.";
 }
 
-.hlx-sk-overlay .modal.modal-preview-not-gdoc::before {
+.hlx-sk-overlay .modal.modal-preview-not-gdoc-generic::before {
   content: "Vorschau-Generierung fehlgeschlagen. Muss ein Google-Dokument oder eine Tabelle sein.";
+}
+
+.hlx-sk-overlay .modal.modal-preview-not-gdoc-ms-doc::before {
+  content: "Previewing failed. This is a Microsoft Doc. Please convert it to a Google Doc: 'File' > 'Save As Google Doc'";
+}
+
+.hlx-sk-overlay .modal.modal-preview-not-gdoc-ms-excel::before {
+  content: "Previewing failed. This is an Excel Sheets Document. Please convert it to Google Sheets: 'File' > 'Save As Google Sheets'";
 }
 
 .hlx-sk-overlay .modal.modal-reload-failure::before {

--- a/src/extension/fr.css
+++ b/src/extension/fr.css
@@ -179,7 +179,7 @@
 }
 
 .hlx-sk-overlay .modal.modal-preview-not-gdoc-ms-doc::before {
-  content: "This is a Microsoft Word document. Please convert it to a Google Doc: File > Save as Google Docs";
+  content: "Ce document est un fichier Microsoft Word, vous devez le convertir en document Google Doc: Fichier > Enregistrer comme Google Docs";
 }
 
 .hlx-sk-overlay .modal.modal-preview-not-gsheet-ms-excel::before {

--- a/src/extension/fr.css
+++ b/src/extension/fr.css
@@ -178,11 +178,11 @@
   content: "La génération de l'aperçu a échoué. Doit être un document Google ou une feuille de calcul.";
 }
 
-.hlx-sk-overlay .modal.modal-preview-not-gdoc-ms-doc::before {
+.hlx-sk-overlay .modal.modal-preview-not-gdoc-ms-word::before {
   content: "Previewing failed. This is a Microsoft Doc. Please convert it to a Google Doc: 'File' > 'Save As Google Doc'";
 }
 
-.hlx-sk-overlay .modal.modal-preview-not-gdoc-ms-excel::before {
+.hlx-sk-overlay .modal.modal-preview-not-gsheet-ms-excel::before {
   content: "Previewing failed. This is an Excel Sheets Document. Please convert it to Google Sheets: 'File' > 'Save As Google Sheets'";
 }
 

--- a/src/extension/fr.css
+++ b/src/extension/fr.css
@@ -174,8 +174,16 @@
   content: "La génération de l'aperçu a échoué. Veuillez essayer plus tard.";
 }
 
-.hlx-sk-overlay .modal.modal-preview-not-gdoc::before {
+.hlx-sk-overlay .modal.modal-preview-not-gdoc-generic::before {
   content: "La génération de l'aperçu a échoué. Doit être un document Google ou une feuille de calcul.";
+}
+
+.hlx-sk-overlay .modal.modal-preview-not-gdoc-ms-doc::before {
+  content: "Previewing failed. This is a Microsoft Doc. Please convert it to a Google Doc: 'File' > 'Save As Google Doc'";
+}
+
+.hlx-sk-overlay .modal.modal-preview-not-gdoc-ms-excel::before {
+  content: "Previewing failed. This is an Excel Sheets Document. Please convert it to Google Sheets: 'File' > 'Save As Google Sheets'";
 }
 
 .hlx-sk-overlay .modal.modal-reload-failure::before {

--- a/src/extension/fr.css
+++ b/src/extension/fr.css
@@ -183,7 +183,7 @@
 }
 
 .hlx-sk-overlay .modal.modal-preview-not-gsheet-ms-excel::before {
-  content: "This is a Microsoft Excel document. Please convert it to Google Sheets: File > Save as Google Sheets";
+  content: "Ce document est un fichier Microsoft Excel, vous devez le convertir en document Google Sheets: Fichier > Enregistrer comme Google Sheets";
 }
 
 .hlx-sk-overlay .modal.modal-reload-failure::before {

--- a/src/extension/module.js
+++ b/src/extension/module.js
@@ -968,15 +968,25 @@
             sk.showModal({
               css: `modal-preview-onedrive${mac}`,
             });
-          } else if (status.edit.sourceLocation?.startsWith('gdrive:')
-            && status.edit.contentType !== 'application/vnd.google-apps.document'
-            && status.edit.contentType !== 'application/vnd.google-apps.spreadsheet') {
-            sk.showModal({
-              css: 'modal-preview-not-gdoc',
-              sticky: true,
-              level: 0,
-            });
-            return;
+          } else if (status.edit.sourceLocation?.startsWith('gdrive:')) {
+            const { contentType } = status.edit;
+            const neitherGdocOrGSheet = !(sk.isGoogleDocMime(contentType)
+            || sk.isGoogleSheetMime(contentType));
+            if (neitherGdocOrGSheet) {
+              let css = 'modal-preview-not-gdoc-generic'; // show generic message by default
+              if (sk.isMsDocMime(contentType)) {
+                css = 'modal-preview-not-gdoc-ms-doc';
+              } else if (sk.isMsExcelSheet(contentType)) {
+                css = 'modal-preview-not-gdoc-ms-excel';
+              }
+              sk.showModal({
+                css,
+                sticky: true,
+                level: 0,
+              });
+
+              return;
+            }
           } else {
             sk.showWait();
           }
@@ -2322,6 +2332,49 @@
         return true;
       }
       return this.status[feature].permissions.includes(permission);
+    }
+
+    /**
+     * Check if mime is that of a Google Doc
+     * see: https://developers.google.com/drive/api/guides/mime-types
+     * @param {string} mimeType the mimetype to check
+     * @returns {boolean} <code>true</code> if mime is that of a google doc, else <code>false</code>
+     */
+    static isGoogleDocMime(mimeType) {
+      return mimeType === 'application/vnd.google-apps.document';
+    }
+
+    /**
+     * Check if mime is that of a Google Sheet
+     * see: https://developers.google.com/drive/api/guides/mime-types
+     * @param {string} mimeType the mimetype to check
+     * @returns {boolean} <code>true</code> if mime is that of a google sheet,
+     *  else <code>false</code>
+     */
+    static isGoogleSheetMime(mimeType) {
+      return mimeType === 'application/vnd.google-apps.spreadsheet';
+    }
+
+    /**
+     * Check if mime is that of a Microsoft Word Doc
+     * see: https://developers.google.com/drive/api/guides/ref-export-formats
+     * @param {string} mimeType the mimetype to check
+     * @returns {boolean} <code>true</code> if mime is that of a microsoft word doc,
+     *  else <code>false</code>
+     */
+    static isMsDocMime(mimeType) {
+      return mimeType === 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
+    }
+
+    /**
+     * Check if mime is that of a Microsoft Excel Sheet
+     * see: https://developers.google.com/drive/api/guides/ref-export-formats
+     * @param {string} mimeType the mimetype to check
+     * @returns {boolean} <code>true</code> if mime is that of a microsoft excel sheet,
+     *  else <code>false</code>
+     */
+    static isMsExcelSheet(mimeType) {
+      return mimeType === 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
     }
 
     /**

--- a/src/extension/module.js
+++ b/src/extension/module.js
@@ -970,14 +970,19 @@
             });
           } else if (status.edit.sourceLocation?.startsWith('gdrive:')) {
             const { contentType } = status.edit;
-            const neitherGdocOrGSheet = !(sk.isGoogleDocMime(contentType)
-            || sk.isGoogleSheetMime(contentType));
+
+            const isGoogleDocMime = contentType === 'application/vnd.google-apps.document';
+            const isGoogleSheetMime = contentType === 'application/vnd.google-apps.spreadsheet';
+            const neitherGdocOrGSheet = !isGoogleDocMime || !isGoogleSheetMime;
+
             if (neitherGdocOrGSheet) {
+              const isMsDocMime = contentType === 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
+              const isMsExcelSheet = contentType === 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
               let css = 'modal-preview-not-gdoc-generic'; // show generic message by default
-              if (sk.isMsDocMime(contentType)) {
-                css = 'modal-preview-not-gdoc-ms-doc';
-              } else if (sk.isMsExcelSheet(contentType)) {
-                css = 'modal-preview-not-gdoc-ms-excel';
+              if (isMsDocMime) {
+                css = 'modal-preview-not-gdoc-ms-word';
+              } else if (isMsExcelSheet) {
+                css = 'modal-preview-not-gsheet-ms-excel';
               }
               sk.showModal({
                 css,
@@ -2332,49 +2337,6 @@
         return true;
       }
       return this.status[feature].permissions.includes(permission);
-    }
-
-    /**
-     * Check if mime is that of a Google Doc
-     * see: https://developers.google.com/drive/api/guides/mime-types
-     * @param {string} mimeType the mimetype to check
-     * @returns {boolean} <code>true</code> if mime is that of a google doc, else <code>false</code>
-     */
-    static isGoogleDocMime(mimeType) {
-      return mimeType === 'application/vnd.google-apps.document';
-    }
-
-    /**
-     * Check if mime is that of a Google Sheet
-     * see: https://developers.google.com/drive/api/guides/mime-types
-     * @param {string} mimeType the mimetype to check
-     * @returns {boolean} <code>true</code> if mime is that of a google sheet,
-     *  else <code>false</code>
-     */
-    static isGoogleSheetMime(mimeType) {
-      return mimeType === 'application/vnd.google-apps.spreadsheet';
-    }
-
-    /**
-     * Check if mime is that of a Microsoft Word Doc
-     * see: https://developers.google.com/drive/api/guides/ref-export-formats
-     * @param {string} mimeType the mimetype to check
-     * @returns {boolean} <code>true</code> if mime is that of a microsoft word doc,
-     *  else <code>false</code>
-     */
-    static isMsDocMime(mimeType) {
-      return mimeType === 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
-    }
-
-    /**
-     * Check if mime is that of a Microsoft Excel Sheet
-     * see: https://developers.google.com/drive/api/guides/ref-export-formats
-     * @param {string} mimeType the mimetype to check
-     * @returns {boolean} <code>true</code> if mime is that of a microsoft excel sheet,
-     *  else <code>false</code>
-     */
-    static isMsExcelSheet(mimeType) {
-      return mimeType === 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
     }
 
     /**


### PR DESCRIPTION
Currently, if the user uploads a Microsoft Word Doc or a an Excel sheet, and does not convert it, the document is authorable in Google Doc/Sheets. When attempting to author, then publish such documents via sidekick, the message displayed says:

> "Previewing failed. Must be Google document or spreadsheet."

As a User, I did not, at first realize that a Microsoft Document and a Google Document are different and that only the latter is supported by helix. This PR shows a more helpful message and instructions to convert the document to a Google Doc/Sheet.

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues


Thanks for contributing!
