### PR TITLE
fix(view-doc-source): missing image when root path is not '/'

### DIFF
--- a/src/extension/_locales/en/messages.json
+++ b/src/extension/_locales/en/messages.json
@@ -224,6 +224,6 @@
     "message": "Checked topics will not be shown anymore. Remove the checkmark next to a topic you wish to see again."
   },
   "open_view_doc_source": {
-    "message": "View source document"
+    "message": "View document source"
   }
 }

--- a/src/extension/background.js
+++ b/src/extension/background.js
@@ -316,7 +316,7 @@ function checkViewDocSource(id) {
         openViewDocSource(id);
       }
     } catch (e) {
-      log.warn(`Error checking view source for url: ${tab.url}`, e);
+      log.warn(`Error checking view document source for url: ${tab.url}`, e);
     }
   });
 }

--- a/src/extension/view-doc-source/index.html
+++ b/src/extension/view-doc-source/index.html
@@ -8,7 +8,7 @@
   </head>
   <body>
     <header>
-      <h1>View Source</h1>
+      <h1>View document source</h1>
       <button id="copy">Copy</button>
     </header>
     <main class="container">

--- a/src/extension/view-doc-source/js/ui.js
+++ b/src/extension/view-doc-source/js/ui.js
@@ -76,13 +76,7 @@ const htmlSourceToEdition = (main, head, url) => {
   });
 
   main.querySelectorAll('picture source').forEach((source) => {
-    if (!source.srcset) return;
-    const content = new URL(url);
-    if (source.srcset.startsWith('./')) {
-      source.srcset = `${content.origin}/${source.srcset.substring(2)}`;
-    } else if (source.srcset.startsWith('/')) {
-      source.srcset = `${content.origin}${source.srcset}`;
-    }
+    source.remove();
   });
 
   blockDivToTable(main);


### PR DESCRIPTION
Images are missing if the root path is not `/` (like https://www.adobe.com/express/).
Also align naming.