### PR TITLE
fix: check for empty dev url

### DIFF
--- a/src/extension/module.js
+++ b/src/extension/module.js
@@ -449,10 +449,13 @@
       repo,
       ref = 'main',
       devMode,
-      devOrigin = 'http://localhost:3000',
       adminVersion,
       _extended,
     } = config;
+    let { devOrigin } = config;
+    if (!devOrigin) {
+      devOrigin = 'http://localhost:3000';
+    }
     if (owner && repo && !_extended) {
       // look for custom config in project
       const configUrl = devMode


### PR DESCRIPTION
JS error in sidekick's `initConfig` if `devOrigin` is an empty string, preventing the sidekick from loading at all.