### PR TITLE
feat: add status attribute to sk custom element

### DIFF
--- a/src/extension/module.js
+++ b/src/extension/module.js
@@ -2716,6 +2716,9 @@
         })
         .then((json) => {
           this.status = json;
+          if (window.hlx.sidekick) {
+            window.hlx.sidekick.setAttribute('data-status', JSON.stringify(json));
+          }
           return json;
         })
         .then((json) => fireEvent(this, 'statusfetched', json))

--- a/test/logout.test.js
+++ b/test/logout.test.js
@@ -13,7 +13,7 @@
 
 import assert from 'assert';
 import {
-  IT_DEFAULT_TIMEOUT, Nock, Setup, TestBrowser,
+  IT_DEFAULT_TIMEOUT, Nock, Setup, TestBrowser, getSidekickDataAttribute,
 } from './utils.js';
 
 import { SidekickTest } from './SidekickTest.js';
@@ -65,5 +65,9 @@ describe('Test sidekick logout', () => {
     const { checkPageResult: config } = await test.run();
 
     assert.ok(!config.authToken, 'Did not remove auth token from config');
+
+    const status = await getSidekickDataAttribute(page, 'status');
+    assert.ok(status, 'Did not set the status data attribute');
+    assert.deepEqual(JSON.parse(status), { status: 401 }, 'Did not set the status data attribute to 401');
   }).timeout(IT_DEFAULT_TIMEOUT);
 });

--- a/test/utils.js
+++ b/test/utils.js
@@ -775,3 +775,19 @@ export function Nock() {
 
   return nocker;
 }
+
+/**
+ * Retrieves the value of a data attribute from the sidekick
+ * @param {*} page The page
+ * @param {*} attribute The name of the data attribute (data-<attribute>)
+ * @returns The data attribute value or null if not found
+ */
+export async function getSidekickDataAttribute(page, attribute) {
+  return page.evaluate((attr) => {
+    const sk = document.querySelector('helix-sidekick');
+    if (sk && sk.hasAttribute(`data-${attr}`)) {
+      return sk.getAttribute(`data-${attr}`);
+    }
+    return null;
+  }, attribute);
+}


### PR DESCRIPTION
Fix #378

@rofe I wanted to add tests but I realised that the sidekick root element does not seem to be tested. I extended the logout test to check the status data attribute but the value is not updated, still trying to debug the whole logic.