### PR TITLE
chore: shorten de and fr descriptions

### DIFF
--- a/src/extension/_locales/de/messages.json
+++ b/src/extension/_locales/de/messages.json
@@ -289,7 +289,7 @@
     "message": "Das Löschen ist fehlgeschlagen. Bitte versuchen Sie es später erneut."
   },
   "description": {
-    "message": "AEM Sidekick ermöglicht Autorinnen und Autoren von AEM-Sites die einfache Vorschau und Veröffentlichung von Inhalten."
+    "message": "AEM Sidekick ermöglicht Autorinnen und Autoren von AEM-Sites die Vorschau und Veröffentlichung von Inhalten."
   },
   "description_shortcut": {
     "message": "Sidekick aktivieren/deaktivieren"

--- a/src/extension/_locales/fr/messages.json
+++ b/src/extension/_locales/fr/messages.json
@@ -289,7 +289,7 @@
     "message": "Échec de la suppression. Réessayez plus tard."
   },
   "description": {
-    "message": "AEM Sidekick permet aux créateurs et créatrices de sites d’AEM de prévisualiser et publier du contenu en toute facilité."
+    "message": "AEM Sidekick permet aux créateurs et créatrices de sites d’AEM de prévisualiser et publier du contenu."
   },
   "description_shortcut": {
     "message": "Activer/désactiver Sidekick"


### PR DESCRIPTION
Error in XCode cloud build: 

> ITMS-90862: Invalid messages file - The messages.json validation failed for locale de in the Safari web extension bundle AEM Sidekick.app/Contents/PlugIns/AEM Sidekick Extension.appex. The description field must be present, of string type, and 112 or fewer characters long.

> ITMS-90862: Invalid messages file - The messages.json validation failed for locale fr in the Safari web extension bundle AEM Sidekick.app/Contents/PlugIns/AEM Sidekick Extension.appex. The description field must be present, of string type, and 112 or fewer characters long.

