### PR TITLE
chore(test): use HeadlessChrome again

### DIFF
--- a/test/SidekickTest.js
+++ b/test/SidekickTest.js
@@ -266,6 +266,9 @@ export class SidekickTest extends EventEmitter {
           return -1;
         }
       }
+      if (url.endsWith('/favicon.ico')) {
+        return { status: 404 };
+      }
       if (url.startsWith('http')) {
         if (url.startsWith('https://rum.hlx.page/')) {
           // dummy response for rum requests

--- a/test/extension/utils.test.js
+++ b/test/extension/utils.test.js
@@ -14,6 +14,7 @@
 
 import sinon from 'sinon';
 import { expect } from '@esm-bundle/chai';
+import { setUserAgent } from '@web/test-runner-commands';
 import chromeMock from './chromeMock.js';
 import fetchMock from './fetchMock.js';
 
@@ -78,6 +79,7 @@ describe('Test extension utils', () => {
     utils = {
       ...exports,
     };
+    await setUserAgent('HeadlessChrome');
   });
 
   afterEach(() => {

--- a/test/module.test.js
+++ b/test/module.test.js
@@ -796,8 +796,8 @@ describe('Test sidekick', () => {
             .innerText),
         }).run();
         assert.ok(
-          checkPageResult.includes('Jun 18, 2021'),
-          'Dates not displayed by info plugin',
+          checkPageResult.includes('18 Jun 2021'),
+          `Dates not displayed by info plugin: ${checkPageResult}`,
         );
       }).timeout(IT_DEFAULT_TIMEOUT);
 

--- a/test/module.test.js
+++ b/test/module.test.js
@@ -796,7 +796,7 @@ describe('Test sidekick', () => {
             .innerText),
         }).run();
         assert.ok(
-          checkPageResult.includes('18 Jun 2021'),
+          checkPageResult.includes('Jun 18, 2021'),
           `Dates not displayed by info plugin: ${checkPageResult}`,
         );
       }).timeout(IT_DEFAULT_TIMEOUT);


### PR DESCRIPTION
use custom user agent, and the code detecting the `alert` would work again

background: `@web/test-runner-chrome` uses the `new` headless mode since [PR 2269](https://github.com/modernweb-dev/web/pull/2269) which no longer inserts a `HeadlessChrome` into the user agent.