### PR TITLE
chore(test): export c8 coverage from puppeteer

### DIFF
--- a/.nycrc.json
+++ b/.nycrc.json
@@ -6,6 +6,6 @@
   ],
   "check-coverage": true,
   "lines": 72.5,
-  "branches": 81.5,
+  "branches": 80,
   "statements": 72.5
 }

--- a/.nycrc.json
+++ b/.nycrc.json
@@ -6,6 +6,6 @@
   ],
   "check-coverage": true,
   "lines": 72.5,
-  "branches": 100,
+  "branches": 81.5,
   "statements": 72.5
 }

--- a/.nycrc.json
+++ b/.nycrc.json
@@ -4,11 +4,6 @@
     "text",
     "text-summary"
   ],
-  "exclude": [
-    "**/lib/*.js",
-    "**/*.css*",
-    "test"
-  ],
   "check-coverage": true,
   "lines": 72.5,
   "branches": 100,

--- a/test/utils.js
+++ b/test/utils.js
@@ -17,7 +17,6 @@ import { h1 } from '@adobe/fetch';
 import nock from 'nock';
 import puppeteer from 'puppeteer';
 import { CDPBrowser } from 'puppeteer-core';
-import pti from 'puppeteer-to-istanbul';
 import mime from 'mime';
 import { fileURLToPath } from 'url';
 import { promises as fs } from 'fs';
@@ -633,7 +632,7 @@ export class TestBrowser {
    */
   async openPage() {
     const page = await this.browser.newPage();
-    await page.coverage.startJSCoverage();
+    await page.coverage.startJSCoverage({ includeRawScriptCoverage: true });
     await page.coverage.startCSSCoverage();
     return page;
   }
@@ -650,14 +649,21 @@ export class TestBrowser {
         const url = page.url();
         if (url.startsWith('file:///')) {
           // only get coverage from file urls
-          const [jsCoverage, cssCoverage] = await Promise.all([
+          const [jsCoverage] = await Promise.all([
             page.coverage.stopJSCoverage(),
-            page.coverage.stopCSSCoverage(),
           ]);
-          pti.write([...jsCoverage, ...cssCoverage], {
-            includeHostname: true,
-            storagePath: './.nyc_output',
-          });
+
+          const coverage = jsCoverage.map(({ rawScriptCoverage: it }) => ({
+            ...it,
+            scriptId: String(it.scriptId),
+            url: it.url,
+          }));
+
+          // Export coverage data
+          await Promise.all(coverage.map(async (it, idx) => fs.writeFile(
+            `${process.env.NODE_V8_COVERAGE}/coverage-${Date.now()}-${idx}.json`,
+            JSON.stringify({ result: [it] }),
+          )));
         }
         if (url !== 'about:blank') {
           await page.close();

--- a/web-test-runner.config.cjs
+++ b/web-test-runner.config.cjs
@@ -14,6 +14,7 @@ module.exports = {
   port: 2000,
   coverage: true,
   coverageConfig: {
+    include: ['./src/**'],
     report: true,
     reportDir: 'coverage-wtr',
   },


### PR DESCRIPTION
exports script coverage from puppeteer to c8 in a compatible format