### PR TITLE
feat: display the sidekick when loading via the API

### DIFF
--- a/src/extension/background.js
+++ b/src/extension/background.js
@@ -31,6 +31,7 @@ import {
   updateProjectConfigs,
   populateDiscoveryCache,
   queryDiscoveryCache,
+  setDisplay,
 } from './utils.js';
 
 /**
@@ -547,6 +548,7 @@ const externalActions = {
           const match = projects.find((p) => p.owner === owner && p.repo === repo);
           if (match) {
             log.info(`enabling sidekick for project ${owner}/${repo} on ${url}`);
+            await setDisplay(true);
             await injectContentScript(tab.id, [match]);
             resolve(true);
           } else {


### PR DESCRIPTION
When using the `loadSidekick` API, we do not expect the Sidekick to respect the display / hidden logic since there is no point of loading a hidden sidekick.
