### PR TITLE
chore: add redirect property

### DIFF
--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -176,6 +176,10 @@
     "plugins": {
       "type": "array",
       "items": { "$ref": "#/$defs/plugin" }
+    },
+    "redirect": {
+      "type": "url",
+      "description": "Loads the sidekick configuration from a different URL"
     }
    },
    "additionalProperties": false


### PR DESCRIPTION
Redirect property allowing to load the sidekick configuration from a central place.