### PR TITLE
feat: allow view doc source on customised sites

### DIFF
--- a/src/extension/background.js
+++ b/src/extension/background.js
@@ -143,9 +143,7 @@ async function guessIfFranklinSite({ id }) {
     chrome.scripting.executeScript({
       target: { tabId: id },
       func: () => {
-        const isFranklinSite = document.head.querySelectorAll('script[src*="scripts.js"]').length > 0
-          && document.head.querySelectorAll('link[href*="styles.css"]').length > 0
-          && document.body.querySelector('main > div') !== null;
+        const isFranklinSite = document.body.querySelector('main > div') !== null;
         chrome.runtime.sendMessage({ isFranklinSite });
       },
     });


### PR DESCRIPTION
If the site does not use `scripts.js` or `styles.css`, `View document source` would not work. The only hard requirement which can even not be changed at project level is the `body > main > div` dom structure. We could restrict the guessing to this only.

Note: this could lead to false positive - a lot of sites are probably using a `body > main > div` structure. The display will then try his best to render a markdown from the non-helix site - result will not be accurate. But this could still be useful to visualise how the document could look like as a Word document (content and sections should appear, page metadata should be correct, only blocks would be missing). 
