### PR TITLE
feat: support helix 5 authorization header in project config

### DIFF
--- a/src/extension/_locales/en/messages.json
+++ b/src/extension/_locales/en/messages.json
@@ -206,6 +206,9 @@
   "config_manual_liveHost_placeholder": {
     "message": "Custom Live Hostname (optional)"
   },
+  "config_manual_authorizationToken_placeholder": {
+    "message": "Authorization Token (optional)"
+  },
   "config_manual_mountpoints_placeholder": {
     "message": "Content URL: https://..."
   },

--- a/src/extension/background.js
+++ b/src/extension/background.js
@@ -33,6 +33,7 @@ import {
   isValidShareURL,
   storeAuthToken,
   updateAdminAuthHeaderRules,
+  updateProjectAuthorizationHeaderRules,
 } from './utils.js';
 
 /**
@@ -652,6 +653,7 @@ const internalActions = {
 
   await updateHelpContent();
   await updateAdminAuthHeaderRules();
+  await updateProjectAuthorizationHeaderRules();
   log.info('sidekick extension initialized');
 })();
 

--- a/src/extension/options.html
+++ b/src/extension/options.html
@@ -27,6 +27,7 @@ governing permissions and limitations under the License.
         <p class="advanced-only"><input type="text" id="edit-previewHost"></p>
         <p class="advanced-only"><input type="text" id="edit-liveHost"></p>
         <p><input type="text" id="edit-host"></p>
+        <p class="advanced-only"><input type="text" id="edit-authorizationToken"></p>
         <p class="advanced-only">
           <input type="checkbox" id="edit-devMode">
           <label for="edit-devMode"></label>

--- a/src/extension/options.js
+++ b/src/extension/options.js
@@ -202,7 +202,7 @@ function editProject(i) {
   getState(async ({ projects = [] }) => {
     const project = projects[i];
 
-    const protectedProjects = await getConfig('local', 'hlxProtectedProjects') || {};
+    const protectedProjects = await getConfig('local', 'hlxSidekickProjects') || {};
     const { owner, repo } = project;
     const handle = `${owner}/${repo}`;
 

--- a/src/extension/utils.js
+++ b/src/extension/utils.js
@@ -671,7 +671,7 @@ export async function setProject(project, cb) {
 /**
  * Sets the authorization header for all requests to protected sites
  */
-export async function updateSiteAuthorizationHeaderRules() {
+export async function updateProjectAuthorizationHeaderRules() {
   try {
     // remove all rules first
     await chrome.declarativeNetRequest.updateSessionRules({
@@ -682,7 +682,7 @@ export async function updateSiteAuthorizationHeaderRules() {
 
     // start site authorization header rules from id 100
     let id = 100;
-    const projects = await getConfig('local', 'hlxProtectedProjects') || [];
+    const projects = await getConfig('local', 'hlxSidekickProjects') || [];
     const addRules = [];
 
     for (const [key, value] of Object.entries(projects)) {
@@ -712,10 +712,10 @@ export async function updateSiteAuthorizationHeaderRules() {
       await chrome.declarativeNetRequest.updateSessionRules({
         addRules,
       });
-      log.debug(`updateSiteAuthorizationHeaderRules: ${addRules.length} rule(s) set`);
+      log.debug(`updateProjectAuthorizationHeaderRules: ${addRules.length} rule(s) set`);
     }
   } catch (e) {
-    log.error(`updateSiteAuthorizationHeaderRules: ${e.message}`);
+    log.error(`updateProjectAuthorizationHeaderRules: ${e.message}`);
   }
 }
 
@@ -729,7 +729,7 @@ export async function setProjectAuthorizationToken(project, authorizationToken) 
   const { owner, repo } = project;
   const projectHandle = `${owner}/${repo}`;
 
-  const protectedProjects = await getConfig('local', 'hlxProtectedProjects') || {};
+  const protectedProjects = await getConfig('local', 'hlxSidekickProjects') || {};
 
   if (!authorizationToken) {
     delete protectedProjects[projectHandle];
@@ -740,9 +740,9 @@ export async function setProjectAuthorizationToken(project, authorizationToken) 
     protectedProjects[projectHandle] = authorizationToken;
   }
 
-  await setConfig('local', { hlxProtectedProjects: protectedProjects });
+  await setConfig('local', { hlxSidekickProjects: protectedProjects });
 
-  updateSiteAuthorizationHeaderRules();
+  updateProjectAuthorizationHeaderRules();
 }
 
 /**

--- a/src/extension/utils.js
+++ b/src/extension/utils.js
@@ -674,7 +674,7 @@ export async function setProject(project, cb) {
 export async function updateProjectAuthorizationHeaderRules() {
   try {
     // remove all rules first
-    await chrome.declarativeNetRequest.updateDynamicRules({
+    await chrome.declarativeNetRequest.updateSessionRules({
       removeRuleIds: (await chrome.declarativeNetRequest.getSessionRules())
         .filter((rule) => rule.id >= 100)
         .map((rule) => rule.id),
@@ -709,7 +709,7 @@ export async function updateProjectAuthorizationHeaderRules() {
     }
 
     if (addRules.length > 0) {
-      await chrome.declarativeNetRequest.updateDynamicRules({
+      await chrome.declarativeNetRequest.updateSessionRules({
         addRules,
       });
       log.debug(`updateProjectAuthorizationHeaderRules: ${addRules.length} rule(s) set`);

--- a/src/extension/utils.js
+++ b/src/extension/utils.js
@@ -674,7 +674,7 @@ export async function setProject(project, cb) {
 export async function updateProjectAuthorizationHeaderRules() {
   try {
     // remove all rules first
-    await chrome.declarativeNetRequest.updateSessionRules({
+    await chrome.declarativeNetRequest.updateDynamicRules({
       removeRuleIds: (await chrome.declarativeNetRequest.getSessionRules())
         .filter((rule) => rule.id >= 100)
         .map((rule) => rule.id),
@@ -709,7 +709,7 @@ export async function updateProjectAuthorizationHeaderRules() {
     }
 
     if (addRules.length > 0) {
-      await chrome.declarativeNetRequest.updateSessionRules({
+      await chrome.declarativeNetRequest.updateDynamicRules({
         addRules,
       });
       log.debug(`updateProjectAuthorizationHeaderRules: ${addRules.length} rule(s) set`);

--- a/src/extension/utils.js
+++ b/src/extension/utils.js
@@ -594,6 +594,7 @@ export function assembleProject({
   devOrigin,
   disabled,
   authToken,
+  authorizationToken,
 }) {
   if (giturl && !owner && !repo) {
     const gh = getGitHubSettings(giturl);
@@ -620,6 +621,7 @@ export function assembleProject({
     ref,
     mountpoints,
     authToken,
+    authorizationToken,
   };
 }
 
@@ -664,6 +666,83 @@ export async function setProject(project, cb) {
   if (typeof cb === 'function') {
     cb(project);
   }
+}
+
+/**
+ * Sets the authorization header for all requests to protected sites
+ */
+export async function updateSiteAuthorizationHeaderRules() {
+  try {
+    // remove all rules first
+    await chrome.declarativeNetRequest.updateSessionRules({
+      removeRuleIds: (await chrome.declarativeNetRequest.getSessionRules())
+        .filter((rule) => rule.id >= 100)
+        .map((rule) => rule.id),
+    });
+
+    // start site authorization header rules from id 100
+    let id = 100;
+    const projects = await getConfig('local', 'hlxProtectedProjects') || [];
+    const addRules = [];
+
+    for (const [key, value] of Object.entries(projects)) {
+      const [owner, repo] = key.split('/');
+      addRules.push({
+        id,
+        priority: 1,
+        action: {
+          type: 'modifyHeaders',
+          requestHeaders: [{
+            operation: 'set',
+            header: 'authorization',
+            value: `token ${value}`,
+          }],
+        },
+        condition: {
+          regexFilter: `^https://[a-z0-9-]+--${repo}--${owner}.aem.(page|live)/.*`,
+          requestMethods: ['get', 'post'],
+          resourceTypes: ['main_frame'],
+        },
+      });
+      id += 1;
+      log.debug('added admin authorization header rule for ', `${owner}/${repo}`);
+    }
+
+    if (addRules.length > 0) {
+      await chrome.declarativeNetRequest.updateSessionRules({
+        addRules,
+      });
+      log.debug(`updateSiteAuthorizationHeaderRules: ${addRules.length} rule(s) set`);
+    }
+  } catch (e) {
+    log.error(`updateSiteAuthorizationHeaderRules: ${e.message}`);
+  }
+}
+
+/**
+ * Sets or clears the authorization token for a project.
+ * @param {Object} project The project settings
+ * @param {string} [authorizationToken] if undefined project will be removed from the protected list
+ * @returns {Promise<void>}
+ */
+export async function setProjectAuthorizationToken(project, authorizationToken) {
+  const { owner, repo } = project;
+  const projectHandle = `${owner}/${repo}`;
+
+  const protectedProjects = await getConfig('local', 'hlxProtectedProjects') || {};
+
+  if (!authorizationToken) {
+    delete protectedProjects[projectHandle];
+  }
+
+  const currentToken = protectedProjects[projectHandle];
+  if (authorizationToken && currentToken !== authorizationToken) {
+    protectedProjects[projectHandle] = authorizationToken;
+  }
+
+  await setConfig('local', { hlxProtectedProjects: protectedProjects });
+
+  updateSiteAuthorizationHeaderRules();
 }
 
 /**
@@ -728,6 +807,10 @@ export async function deleteProject(handle, cb) {
         // remove project entry from index
         projects.splice(i, 1);
         await setConfig('sync', { hlxSidekickProjects: projects });
+
+        // remove project from protected projects
+        setProjectAuthorizationToken({ owner, repo });
+
         log.info('project deleted', handle);
         if (typeof cb === 'function') cb(true);
       } catch (e) {
@@ -799,9 +882,10 @@ export function toggleDisplay(cb) {
  */
 export async function updateAdminAuthHeaderRules() {
   try {
-    // remove all rules first
+    // remove all rules first.. admin rules ids are < 100
     await chrome.declarativeNetRequest.updateSessionRules({
       removeRuleIds: (await chrome.declarativeNetRequest.getSessionRules())
+        .filter((rule) => rule.id < 100)
         .map((rule) => rule.id),
     });
     // find projects with auth tokens and add rules for each

--- a/test/extension/utils.test.js
+++ b/test/extension/utils.test.js
@@ -403,7 +403,7 @@ describe('Test extension utils', () => {
     const rules = await chrome.declarativeNetRequest.getSessionRules();
     expect(rules).to.deep.equal([]);
 
-    const protectedProject = await utils.getConfig('local', 'hlxProtectedProjects');
+    const protectedProject = await utils.getConfig('local', 'hlxSidekickProjects');
     expect(protectedProject).to.deep.equal({});
   });
 
@@ -466,13 +466,13 @@ describe('Test extension utils', () => {
       repo: 'bar',
     }, '1234');
 
-    let protectedProject = await utils.getConfig('local', 'hlxProtectedProjects');
+    let protectedProject = await utils.getConfig('local', 'hlxSidekickProjects');
     expect(protectedProject).to.deep.equal({
       'foo/bar': '1234',
     });
 
     expect(spy.calledWith({
-      hlxProtectedProjects: {
+      hlxSidekickProjects: {
         'foo/bar': '1234',
       },
     })).to.be.true;
@@ -482,22 +482,22 @@ describe('Test extension utils', () => {
       repo: 'bar',
     }, undefined);
 
-    protectedProject = await utils.getConfig('local', 'hlxProtectedProjects');
+    protectedProject = await utils.getConfig('local', 'hlxSidekickProjects');
     expect(protectedProject).to.deep.equal({});
 
     expect(spy.calledWith({
-      hlxProtectedProjects: {},
+      hlxSidekickProjects: {},
     })).to.be.true;
   });
 
-  it('updateSiteAuthorizationHeaderRules adds and removes', async () => {
+  it('updateProjectAuthorizationHeaderRules adds and removes', async () => {
     const spy = sandbox.spy(chrome.declarativeNetRequest, 'updateSessionRules');
     await utils.setProjectAuthorizationToken({
       owner: 'foo',
       repo: 'bar',
     }, '1234');
 
-    await utils.updateSiteAuthorizationHeaderRules();
+    await utils.updateProjectAuthorizationHeaderRules();
     expect(spy.calledWith([
       {
         id: 100,

--- a/test/extension/utils.test.js
+++ b/test/extension/utils.test.js
@@ -400,7 +400,7 @@ describe('Test extension utils', () => {
       hlxSidekickProjects: ['test/project', 'test/auth-project'],
     })).to.be.true;
 
-    const rules = await chrome.declarativeNetRequest.getDynamicRules();
+    const rules = await chrome.declarativeNetRequest.getSessionRules();
     expect(rules).to.deep.equal([]);
 
     const protectedProject = await utils.getConfig('local', 'hlxSidekickProjects');
@@ -530,7 +530,7 @@ describe('Test extension utils', () => {
       repo: 'bar',
     }, undefined);
 
-    const rules = await chrome.declarativeNetRequest.getDynamicRules();
+    const rules = await chrome.declarativeNetRequest.getSessionRules();
     expect(rules).to.deep.equal([]);
   });
 });

--- a/test/extension/utils.test.js
+++ b/test/extension/utils.test.js
@@ -400,7 +400,7 @@ describe('Test extension utils', () => {
       hlxSidekickProjects: ['test/project', 'test/auth-project'],
     })).to.be.true;
 
-    const rules = await chrome.declarativeNetRequest.getSessionRules();
+    const rules = await chrome.declarativeNetRequest.getDynamicRules();
     expect(rules).to.deep.equal([]);
 
     const protectedProject = await utils.getConfig('local', 'hlxSidekickProjects');
@@ -530,7 +530,7 @@ describe('Test extension utils', () => {
       repo: 'bar',
     }, undefined);
 
-    const rules = await chrome.declarativeNetRequest.getSessionRules();
+    const rules = await chrome.declarativeNetRequest.getDynamicRules();
     expect(rules).to.deep.equal([]);
   });
 });

--- a/test/extension/utils.test.js
+++ b/test/extension/utils.test.js
@@ -386,6 +386,12 @@ describe('Test extension utils', () => {
 
   it('deleteProject', async () => {
     const spy = sandbox.spy(window.chrome.storage.sync, 'set');
+
+    await utils.setProjectAuthorizationToken({
+      owner: 'adobe',
+      repo: 'blog',
+    }, '1234');
+
     const deleted = await new Promise((resolve) => {
       utils.deleteProject('adobe/blog', resolve);
     });
@@ -393,6 +399,12 @@ describe('Test extension utils', () => {
     expect(spy.calledWith({
       hlxSidekickProjects: ['test/project', 'test/auth-project'],
     })).to.be.true;
+
+    const rules = await chrome.declarativeNetRequest.getSessionRules();
+    expect(rules).to.deep.equal([]);
+
+    const protectedProject = await utils.getConfig('local', 'hlxProtectedProjects');
+    expect(protectedProject).to.deep.equal({});
   });
 
   it('setDisplay', async () => {
@@ -445,5 +457,80 @@ describe('Test extension utils', () => {
     const spy = sandbox.spy(window.chrome.storage.session, 'remove');
     await utils.storeAuthToken('foo', '');
     expect(spy.calledWith('foo')).to.be.true;
+  });
+
+  it('setProjectAuthorizationToken (add and remove)', async () => {
+    const spy = sandbox.spy(window.chrome.storage.local, 'set');
+    await utils.setProjectAuthorizationToken({
+      owner: 'foo',
+      repo: 'bar',
+    }, '1234');
+
+    let protectedProject = await utils.getConfig('local', 'hlxProtectedProjects');
+    expect(protectedProject).to.deep.equal({
+      'foo/bar': '1234',
+    });
+
+    expect(spy.calledWith({
+      hlxProtectedProjects: {
+        'foo/bar': '1234',
+      },
+    })).to.be.true;
+
+    await utils.setProjectAuthorizationToken({
+      owner: 'foo',
+      repo: 'bar',
+    }, undefined);
+
+    protectedProject = await utils.getConfig('local', 'hlxProtectedProjects');
+    expect(protectedProject).to.deep.equal({});
+
+    expect(spy.calledWith({
+      hlxProtectedProjects: {},
+    })).to.be.true;
+  });
+
+  it('updateSiteAuthorizationHeaderRules adds and removes', async () => {
+    const spy = sandbox.spy(chrome.declarativeNetRequest, 'updateSessionRules');
+    await utils.setProjectAuthorizationToken({
+      owner: 'foo',
+      repo: 'bar',
+    }, '1234');
+
+    await utils.updateSiteAuthorizationHeaderRules();
+    expect(spy.calledWith([
+      {
+        id: 100,
+        priority: 1,
+        action: {
+          type: 'modifyHeaders',
+          requestHeaders: [
+            {
+              operation: 'set',
+              header: 'authorization',
+              value: 'token 1234',
+            },
+          ],
+        },
+        condition: {
+          regexFilter: '^https://[a-z0-9-]+--bar--foo.aem.(page|live)/.*',
+          requestMethods: [
+            'get',
+            'post',
+          ],
+          resourceTypes: [
+            'main_frame',
+          ],
+        },
+      },
+    ]));
+
+    await utils.setProjectAuthorizationToken({
+      owner: 'foo',
+      repo: 'bar',
+    }, undefined);
+
+    const rules = await chrome.declarativeNetRequest.getSessionRules();
+    expect(rules).to.deep.equal([]);
   });
 });


### PR DESCRIPTION
Allow the options page to define an authorization header for project-specific top-level browser requests. Required for sites with authentication enabled in helix 5.

Fixes #737 