### PR TITLE
fix: account for url's with fragments when adding nocache query param

### DIFF
--- a/src/extension/module.js
+++ b/src/extension/module.js
@@ -4067,12 +4067,9 @@ import sampleRUM from './rum.js';
       const liveDomains = ['aem.live', 'hlx.live'];
       if (cacheBust
         && !(targetEnv === 'prod' && !liveDomains.some((domain) => envUrl.includes(domain)) && this.config.transient)) {
-        const [baseUrl, fragment] = envUrl.split('#');
-        const separator = baseUrl.includes('?') ? '&' : '?';
-        envUrl = `${baseUrl}${separator}nocache=${Date.now()}`;
-        if (fragment) {
-          envUrl += `#${fragment}`;
-        }
+        const url = new URL(envUrl);
+        url.searchParams.set('nocache', Date.now());
+        envUrl = url.toString();
       }
 
       // switch or open env

--- a/src/extension/module.js
+++ b/src/extension/module.js
@@ -4067,8 +4067,12 @@ import sampleRUM from './rum.js';
       const liveDomains = ['aem.live', 'hlx.live'];
       if (cacheBust
         && !(targetEnv === 'prod' && !liveDomains.some((domain) => envUrl.includes(domain)) && this.config.transient)) {
-        const separator = envUrl.includes('?') ? '&' : '?';
-        envUrl = `${envUrl}${separator}nocache=${Date.now()}`;
+        const [baseUrl, fragment] = envUrl.split('#');
+        const separator = baseUrl.includes('?') ? '&' : '?';
+        envUrl = `${baseUrl}${separator}nocache=${Date.now()}`;
+        if (fragment) {
+          envUrl += `#${fragment}`;
+        }
       }
 
       // switch or open env

--- a/test/SidekickTest.js
+++ b/test/SidekickTest.js
@@ -248,6 +248,7 @@ export class SidekickTest extends EventEmitter {
         method: req.method,
         headers: req.headers,
         url,
+        urlFragment: req.urlFragment,
       };
       if (this.requestHandler) {
         const r = await this.requestHandler(reqObj);

--- a/test/publish.test.js
+++ b/test/publish.test.js
@@ -63,6 +63,27 @@ describe('Test publish plugin', () => {
     assert.ok(navigated.startsWith('https://blog.adobe.com/en/topics/bla?nocache='), 'Redirect not sent');
   }).timeout(IT_DEFAULT_TIMEOUT);
 
+  it('Publish works with fragment and nocache', async () => {
+    const setup = new Setup('blog');
+    nock.sidekick(setup);
+    nock.admin(setup);
+    nock('https://admin.hlx.page')
+      .post('/live/adobe/blog/main/en/topics/bla')
+      .reply(200);
+    const { requestsMade } = await new SidekickTest({
+      browser,
+      page,
+      plugin: 'publish',
+      url: 'https://main--blog--adobe.hlx.page/en/topics/bla#fragment',
+      waitNavigation: 'https://blog.adobe.com/en/topics/bla?nocache=',
+    }).run();
+    const navigationRequest = requestsMade.find((r) => r.url.includes('https://blog.adobe.com/en/topics/bla?nocache='));
+    assert.equal(
+      navigationRequest.urlFragment,
+      '#fragment',
+    );
+  }).timeout(IT_DEFAULT_TIMEOUT);
+
   it('Publish plugin also publishes dependencies', async () => {
     const setup = new Setup('blog');
     nock.sidekick(setup);


### PR DESCRIPTION
If the url contains a fragment the `nocache` query param should come before the fragment. Currently we are just appending it on to the url and not factoring in the edge cache where the url contains a fragment on `.page` and then is published.

fixes #750 