### PR TITLE
fix: Authorization header is not sent for page subresources

### DIFF
--- a/src/extension/utils.js
+++ b/src/extension/utils.js
@@ -703,7 +703,15 @@ export async function updateProjectAuthorizationHeaderRules() {
         condition: {
           regexFilter: `^https://[a-z0-9-]+--${repo}--${owner}.aem.(page|live)/.*`,
           requestMethods: ['get', 'post'],
-          resourceTypes: ['main_frame'],
+          resourceTypes: [
+            'main_frame',
+            'script',
+            'stylesheet',
+            'image',
+            'xmlhttprequest',
+            'media',
+            'font',
+          ],
         },
       });
       id += 1;

--- a/test/extension/utils.test.js
+++ b/test/extension/utils.test.js
@@ -520,6 +520,12 @@ describe('Test extension utils', () => {
           ],
           resourceTypes: [
             'main_frame',
+            'script',
+            'stylesheet',
+            'image',
+            'xmlhttprequest',
+            'media',
+            'font',
           ],
         },
       },


### PR DESCRIPTION
The current implementation of the sidekick is only sending the authorization header for the main document, but not for the subresources (scripts, stylesheets, images, etc.).
This PR ensures that all subresources are loaded when helix 5 authentication is enabled and the page renders.

**Before:**
<img width="855" alt="Screenshot 2024-08-29 at 10 09 40" src="https://github.com/user-attachments/assets/e94fc2bb-b4eb-40e6-811d-0b876c5cd6f5">


**After:**
<img width="883" alt="Screenshot 2024-08-29 at 10 08 49" src="https://github.com/user-attachments/assets/6e9e0bf8-0ae2-48f3-8679-0a012445c7e7">
