### PR TITLE
fix(rum): instrument options page

### DIFF
--- a/src/extension/options.js
+++ b/src/extension/options.js
@@ -349,6 +349,11 @@ async function updateHelpTopic(helpContent, topicId, userStatus) {
 }
 
 // instrumentation
+window.hlx = {
+  sidekick: {
+    location: window.location,
+  },
+};
 sampleRUM('sidekick:options:opened');
 document.addEventListener('click', ({ target }) => {
   if (['A', 'BUTTON'].includes(target.tagName)


### PR DESCRIPTION
`sampleRUM` currently fails due to the missing sidekick object.