### PR TITLE
Allow calls to admin.hlx.page job details to work from log-viewer when requireAuth is not false

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adobe/helix-sidekick-extension",
-  "version": "6.49.0",
+  "version": "6.49.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@adobe/helix-sidekick-extension",
-      "version": "6.49.0",
+      "version": "6.49.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@adobe/eslint-config-helix": "2.0.7",

--- a/src/extension/utils.js
+++ b/src/extension/utils.js
@@ -561,7 +561,7 @@ export async function updateAuthHeaderRules() {
             regexFilter: `^https://admin.hlx.page/[a-z]+/${owner}/.*`,
             requestDomains: ['admin.hlx.page'],
             requestMethods: ['get', 'post', 'delete'],
-            resourceTypes: ['xmlhttprequest'],
+            resourceTypes: ['main_frame', 'xmlhttprequest'],
           },
         });
         id += 1;


### PR DESCRIPTION
## Related Issues
#810 