### PR TITLE
fix: cookie-less auth cleanup. remove credentials: include

### DIFF
--- a/src/extension/module.js
+++ b/src/extension/module.js
@@ -572,13 +572,12 @@ import sampleRUM from './rum.js';
 
   /**
    * Returns the fetch options for admin requests
-   * @param {boolean} omitCredentials Should we omit the credentials
    * @returns {object}
    */
-  function getAdminFetchOptions(omitCredentials = false) {
+  function getAdminFetchOptions() {
     const opts = {
       cache: 'no-store',
-      credentials: omitCredentials ? 'omit' : 'include',
+      credentials: 'omit',
       headers: {},
     };
     return opts;
@@ -651,7 +650,7 @@ import sampleRUM from './rum.js';
         ? `${devOrigin}/tools/sidekick/config.json`
         : getAdminUrl(config, 'sidekick', '/config.json');
       try {
-        const res = await fetch(configUrl, getAdminFetchOptions(true));
+        const res = await fetch(configUrl, getAdminFetchOptions());
         if (res.status === 200) {
           config = {
             ...config,

--- a/src/extension/utils.js
+++ b/src/extension/utils.js
@@ -695,7 +695,7 @@ export async function getProjectEnv({
   try {
     const options = {
       cache: 'no-store',
-      credentials: 'include',
+      credentials: 'omit',
       headers: authToken ? { 'x-auth-token': authToken } : {},
     };
     res = await fetch(`https://admin.hlx.page/sidekick/${owner}/${repo}/${ref}/config.json`, options);

--- a/test/SidekickTest.js
+++ b/test/SidekickTest.js
@@ -356,6 +356,12 @@ export class SidekickTest extends EventEmitter {
               }
               input.value = testLocation;
             }
+            // Mock sidekick's extension ID
+            window.chrome = {
+              runtime: {
+                id: 'testsidekickid',
+              },
+            };
             // inject sidekick
             const moduleScript = document.createElement('script');
             moduleScript.id = 'hlx-sk-module';

--- a/test/logout.test.js
+++ b/test/logout.test.js
@@ -49,7 +49,7 @@ describe('Test sidekick logout', () => {
     nock('https://admin.hlx.page')
       .get('/status/adobe/blog/main/en/topics/bla?editUrl=auto')
       .reply(200, { status: 200 })
-      .get('/logout/adobe/blog/main?extensionId=cookie')
+      .get('/logout/adobe/blog/main?extensionId=testsidekickid')
       .reply(200, '<html>logged out<script>setTimeout(() => self.close(), 500)</script></html>')
       .get('/profile/adobe/blog/main')
       .reply(401, '{ "status": 401 }', { 'content-type': 'application/json' });

--- a/test/module.test.js
+++ b/test/module.test.js
@@ -1322,7 +1322,7 @@ describe('Test sidekick', () => {
     nock.sidekick(setup);
     nock.admin(setup);
     nock('https://admin.hlx.page')
-      .get('/login/adobe/blog/main?extensionId=cookie')
+      .get('/login/adobe/blog/main?extensionId=testsidekickid')
       .optionally()
       .reply(200, '<html>logged in</html>')
       .get('/profile/adobe/blog/main')
@@ -1378,7 +1378,7 @@ describe('Test sidekick', () => {
     nock.sidekick(setup);
     nock.admin(setup);
     nock('https://admin.hlx.page')
-      .get('/login/adobe/blog/main?extensionId=cookie&selectAccount=true')
+      .get('/login/adobe/blog/main?extensionId=testsidekickid&selectAccount=true')
       .optionally()
       .reply(200, '<html>logged in</html>')
       .get('/profile/adobe/blog/main')

--- a/test/unpublish.test.js
+++ b/test/unpublish.test.js
@@ -84,13 +84,14 @@ describe('Test unpublish plugin', () => {
   }).timeout(IT_DEFAULT_TIMEOUT);
 
   it('Unpublish plugin hidden if source document still exists but user is authenticated', async () => {
+    let mockToken = null;
     const setup = new Setup('blog');
     nock.login();
     nock('https://admin.hlx.page')
       .get('/sidekick/adobe/blog/main/config.json')
       .twice()
       .reply(function req() {
-        if (this.req.headers.cookie === 'auth_token=foobar') {
+        if (this.req.headers.authorization === `token ${mockToken}`) {
           return [200, '{}', { 'content-type': 'application/json' }];
         }
         return [401];
@@ -98,20 +99,21 @@ describe('Test unpublish plugin', () => {
       .get('/status/adobe/blog/main/en/topics/bla?editUrl=auto')
       .twice()
       .reply(function req() {
-        if (this.req.headers.cookie === 'auth_token=foobar') {
+        if (this.req.headers.authorization === `token ${mockToken}`) {
           const resp = setup.apiResponse();
           resp.live.permissions.push('delete'); // authenticated request, add delete permission
           return [200, JSON.stringify(resp), { 'content-type': 'application/json' }];
         }
         return [401, '{ "status": 401 }', { 'content-type': 'application/json' }];
       })
-      .get('/login/adobe/blog/main?extensionId=cookie')
-      .reply(200, '<html>logged in<script>setTimeout(() => self.close(), 500)</script></html>', {
-        'set-cookie': 'auth_token=foobar; Path=/; HttpOnly; Secure; SameSite=None',
+      .get('/login/adobe/blog/main?extensionId=testsidekickid')
+      .reply(() => {
+        mockToken = 'test-token'; // mock admin sending token to the background extension worker
+        return [200, '<html>logged in<script>setTimeout(() => self.close(), 500)</script></html>'];
       })
       .get('/profile/adobe/blog/main')
       .reply(function req() {
-        if (this.req.headers.cookie === 'auth_token=foobar') {
+        if (this.req.headers.authorization === `token ${mockToken}`) {
           return [200, '{ "status": 200 }', { 'content-type': 'application/json' }];
         }
         return [401, '{ "status": 401 }', { 'content-type': 'application/json' }];
@@ -127,6 +129,14 @@ describe('Test unpublish plugin', () => {
       plugin: 'user-login',
       pluginSleep: 2000,
       loadModule: true,
+      requestHandler: (request) => {
+        if (new URL(request.url).hostname !== 'admin.hlx.page') return;
+
+        if (mockToken) {
+          // mock admin sending token from background extension worker
+          request.headers.authorization = `token ${mockToken}`;
+        }
+      },
     }).run();
     assert.ok(
       plugins.find((p) => p.id === 'unpublish' && p.classes.includes('hlx-sk-advanced-only')),


### PR DESCRIPTION
Since the AEM Sidekick no longer uses cookies for authentication to Admin, we can remove the `credentials: 'include'` option from fetch requests to Admin.

Manually the following flows in the browser:

Site with Admin Without login (Sharepoint)
 * Preview
 * Publish
 * Login
 * Status
 * Profile
 * Logout
 * Unpublish
 * Delete

Site with Admin With login (Sharepoint)
 * Login
 * Logout
 * Preview
 * Publish
 * Status
 * Profile
 * Unpublish
 * Delete
 * Extensions loaded

Site with Admin with login (Google Drive)
 * Login
 * Logout
 * Preview
 * Publish
 * Status
 * Profile
 * Unpublish
 * Delete