### PR TITLE
fix: if v7 sidekick exists on page, don't open custom views

### DIFF
--- a/src/extension/module.js
+++ b/src/extension/module.js
@@ -3050,7 +3050,8 @@ import sampleRUM from './rum.js';
    * @param {Sidekick} sk The sidekick
    */
   async function showView(sk) {
-    if (!sk.isProject()) {
+    const v7Sidekick = document.querySelector('aem-sidekick');
+    if (!sk.isProject() || v7Sidekick) {
       return;
     }
     const {


### PR DESCRIPTION
fixes #863 
